### PR TITLE
changed from using innerText property to using textContent property

### DIFF
--- a/jfont-checker.js
+++ b/jfont-checker.js
@@ -21,8 +21,8 @@
 		containerA = document.createElement("span");
 		containerB = document.createElement("span");
 
-		containerA.innerText = filler;
-		containerB.innerText = filler;
+		containerA.textContent = filler;
+		containerB.textContent = filler;
 
 		var styles = {
 			margin: "0",


### PR DESCRIPTION
Firefox does not (yet) support the innerText property of DOM elements, so I changed it to using the textContent property which is standard compliant
Note: textContent is not supported by IE8 and lower.
